### PR TITLE
Contractor 3.1.0

### DIFF
--- a/Contractor.CLI.Tests/ContractorXmlValidatorTests.cs
+++ b/Contractor.CLI.Tests/ContractorXmlValidatorTests.cs
@@ -41,8 +41,8 @@ namespace Contractor.CLI.Tests
             var contractorXml = new ContractorXmlBuilder()
                 .AddEntity(entity => entity
                     .WithName("Entity1", "Entity1s")
-                    .WithProperty("String", "Property1")
-                    .WithProperty("String", "Property1")) // Duplicate
+                    .WithProperty("String:50", "Property1")
+                    .WithProperty("String:50", "Property1")) // Duplicate
                 .Build();
 
             // Act & Assert
@@ -72,7 +72,7 @@ namespace Contractor.CLI.Tests
             var contractorXml = new ContractorXmlBuilder()
                 .AddEntity(entity => entity
                     .WithName("Entity1", "Entity1s")
-                    .WithProperty("String", "Property1")
+                    .WithProperty("String:50", "Property1")
                     .WithIndex("Property1", "NonexistentProperty"))
                 .Build();
 
@@ -132,21 +132,66 @@ namespace Contractor.CLI.Tests
         }
         
         [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void ValidateUniqueRelations_StringMissingMaxLength_ThrowsFormatException()
+        {
+            // Arrange
+            var contractorXml = new ContractorXmlBuilder()
+                .AddEntity(entity => entity
+                    .WithName("Customer", "Customers")
+                    .WithProperty("String", "Name"))
+                .Build();
+
+            // Act & Assert
+            ContractorXmlValidator.Validate(contractorXml);
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void ValidateUniqueRelations_MaxLengthLowerThanMinLength_ThrowsFormatException()
+        {
+            // Arrange
+            var contractorXml = new ContractorXmlBuilder()
+                .AddEntity(entity => entity
+                    .WithName("Customer", "Customers")
+                    .WithProperty("String:15", "Name", 50))
+                .Build();
+
+            // Act & Assert
+            ContractorXmlValidator.Validate(contractorXml);
+        }
+        
+        [TestMethod]
+        [ExpectedException(typeof(FormatException))]
+        public void ValidateUniqueRelations_MinLengthLowerZero_ThrowsFormatException()
+        {
+            // Arrange
+            var contractorXml = new ContractorXmlBuilder()
+                .AddEntity(entity => entity
+                    .WithName("Customer", "Customers")
+                    .WithProperty("String:15", "Name", -1))
+                .Build();
+
+            // Act & Assert
+            ContractorXmlValidator.Validate(contractorXml);
+        }
+        
+        [TestMethod]
         public void ValidateComplexModel_DoesNotThrowException()
         {
             // Arrange
             var contractorXml = new ContractorXmlBuilder()
                 .AddEntity(entity => entity
                     .WithName("Customer", "Customers")
-                    .WithProperty("String", "Name")
-                    .WithProperty("String", "Email"))
+                    .WithProperty("String:50", "Name", 3)
+                    .WithProperty("String:50", "Email", 0))
                 .AddEntity(entity => entity
                     .WithName("Order", "Orders")
                     .WithRelation1ToN("Customer", "Customer", "Orders")
                     .WithProperty("DateTime", "OrderDate"))
                 .AddEntity(entity => entity
                     .WithName("Product", "Products")
-                    .WithProperty("String", "Name")
+                    .WithProperty("String:50", "Name")
                     .WithProperty("Double", "Price"))
                 .AddEntity(entity => entity
                     .WithName("OrderDetail", "OrderDetails")

--- a/Contractor.CLI.Tests/EntityXmlBuilder.cs
+++ b/Contractor.CLI.Tests/EntityXmlBuilder.cs
@@ -27,6 +27,17 @@ public class EntityXmlBuilder
         return this;
     }
 
+    public EntityXmlBuilder WithProperty(string type, string name, int minLength)
+    {
+        _entity.Properties.Add(new PropertyXml
+        {
+            Type = type,
+            Name = name,
+            MinLength = minLength.ToString(),
+        });
+        return this;
+    }
+
     public EntityXmlBuilder WithRelation1ToN(string entityNameFrom)
     {
         _entity.Relation1ToN.Add(new Relation1ToNXml { EntityNameFrom = entityNameFrom });

--- a/Contractor.CLI.Tests/XmlIntegrationTest.cs
+++ b/Contractor.CLI.Tests/XmlIntegrationTest.cs
@@ -1,0 +1,119 @@
+using System.Xml;
+using System.Xml.Serialization;
+using Contractor.Core.MetaModell;
+
+namespace Contractor.CLI.Tests
+{
+    [TestClass]
+    public class XmlIntegrationTest
+    {
+        [TestMethod]
+        public void Test_ToContractorGenerationOptions_ShouldConvertCorrectly()
+        {
+            // Arrange
+            var xmlString = @"<?xml version=""1.0"" encoding=""UTF-8""?>
+<Contractor minContractorVersion=""2.8.3"">
+  <Paths>
+    <BackendDestinationFolder>../Backend</BackendDestinationFolder>
+    <BackendGeneratedDestinationFolder>..\Backend.Generated</BackendGeneratedDestinationFolder>
+    <DbDestinationFolder>..\Database</DbDestinationFolder>
+    <FrontendDestinationFolder>../Frontend</FrontendDestinationFolder>
+    <ProjectName>MyProject</ProjectName>
+    <GeneratedProjectName>MyProject.Generated</GeneratedProjectName>
+    <DbProjectName>MyProject.Database</DbProjectName>
+    <DbContextName>MyProjectDbContext</DbContextName>
+  </Paths>
+  <Replacements>
+    <Replacement pattern=""old"" replaceWith=""new""/>
+  </Replacements>
+  <Modules>
+    <Module name=""SampleModule"">
+      <Entity name=""SampleEntity"" namePlural=""SampleEntities"">
+        <Property name=""BezeichnungKurz"" type=""String:256""/>
+        <Property name=""BezeichnungLang"" type=""String:5000"" minLength=""0""/>
+        <Relation1ToN entityNameFrom=""OtherEntity"" propertyNameFrom=""OtherProperty""/>
+        <Index property=""Name"" unique=""true""/>
+        <Check name=""CheckName"" query=""SomeQuery""/>
+      </Entity>
+    </Module>
+  </Modules>
+  <PurposeDtos>
+    <PurposeDto entity=""SampleEntity"" purpose=""SomePurpose"">
+      <Property path=""Name""/>
+    </PurposeDto>
+  </PurposeDtos>
+  <Interfaces>
+    <Interface name=""SampleInterface"">
+      <Property name=""Name""/>
+    </Interface>
+  </Interfaces>
+</Contractor>";
+
+            var contractorXmlSerializer = new XmlSerializer(typeof(ContractorXml));
+
+            // Act
+            ContractorXml contractorXml;
+            using var stringReader = new StringReader(xmlString);
+            using var xmlReader = XmlReader.Create(stringReader);
+            contractorXml = (ContractorXml)contractorXmlSerializer.Deserialize(xmlReader)!;
+
+            contractorXml.Includes ??= new();
+            contractorXml.PurposeDtos ??= new();
+            contractorXml.Interfaces ??= new();
+            contractorXml.Modules ??= new();
+
+            string baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
+
+            GenerationOptions generationOptions = ContractorXmlConverter
+                .ToContractorGenerationOptions(contractorXml, baseDirectory);
+
+            // Assert
+            Assert.IsNotNull(generationOptions);
+
+            // Assert Modules
+            Assert.AreEqual(1, generationOptions.Modules.Count);
+            var module = generationOptions.Modules[0];
+            Assert.AreEqual("SampleModule", module.Name);
+            Assert.AreEqual(1, module.Entities.Count);
+            var entity = module.Entities[0];
+            Assert.AreEqual("SampleEntity", entity.Name);
+            Assert.AreEqual(2, entity.Properties.Count);
+            Assert.AreEqual("BezeichnungKurz", entity.Properties[0].Name);
+            Assert.AreEqual("String", entity.Properties[0].Type);
+            Assert.AreEqual("256", entity.Properties[0].TypeExtra);
+            Assert.AreEqual(1, entity.Properties[0].MinLength);
+            Assert.AreEqual("BezeichnungLang", entity.Properties[1].Name);
+            Assert.AreEqual("String", entity.Properties[1].Type);
+            Assert.AreEqual("5000", entity.Properties[1].TypeExtra);
+            Assert.AreEqual(0, entity.Properties[1].MinLength);
+
+            // Assert Relations
+            Assert.AreEqual(1, entity.Relations1ToN.Count);
+            Assert.AreEqual("OtherProperty", entity.Relations1ToN[0].PropertyNameInSource);
+
+            // Assert Indexes
+            Assert.AreEqual(1, entity.Indices.Count);
+            Assert.IsTrue(entity.Indices[0].IsUnique);
+
+            // Assert Checks
+            Assert.AreEqual(1, entity.Checks.Count);
+            Assert.AreEqual("CheckName", entity.Checks[0].Name);
+            Assert.AreEqual("SomeQuery", entity.Checks[0].Query);
+
+            // Assert PurposeDtos
+            Assert.AreEqual(1, generationOptions.PurposeDtos.Count);
+            var purposeDto = generationOptions.PurposeDtos[0];
+            Assert.AreEqual("SampleEntity", purposeDto.EntityName);
+            Assert.AreEqual("SomePurpose", purposeDto.Purpose);
+            Assert.AreEqual(1, purposeDto.Properties.Count);
+            Assert.AreEqual("Name", purposeDto.Properties[0].Path);
+
+            // Assert Interfaces
+            Assert.AreEqual(1, generationOptions.Interfaces.Count);
+            var interfaceItem = generationOptions.Interfaces[0];
+            Assert.AreEqual("SampleInterface", interfaceItem.Name);
+            Assert.AreEqual(1, interfaceItem.Properties.Count);
+            Assert.AreEqual("Name", interfaceItem.Properties[0].Name);
+        }
+    }
+}

--- a/Contractor.CLI/Contractor.CLI.csproj
+++ b/Contractor.CLI/Contractor.CLI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>contractor</PackageId>
     <Title>contractor</Title>
-    <Version>3.0.1</Version>
+    <Version>3.0.2</Version>
     <Summary>Der Contractor ist eine CLI um Domänen, Entitäten, Eigenschaften und Beziehungen zur Contract Architektur hinzuzufügen.</Summary>
     <Description>Der Contractor ist eine CLI um Domänen, Entitäten, Eigenschaften und Beziehungen zur Contract Architektur hinzuzufügen.</Description>
     <Authors>Jonas Hammerschmidt</Authors>

--- a/Contractor.CLI/Contractor.CLI.csproj
+++ b/Contractor.CLI/Contractor.CLI.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <PackageId>contractor</PackageId>
     <Title>contractor</Title>
-    <Version>3.0.2</Version>
+    <Version>3.1.0</Version>
     <Summary>Der Contractor ist eine CLI um Domänen, Entitäten, Eigenschaften und Beziehungen zur Contract Architektur hinzuzufügen.</Summary>
     <Description>Der Contractor ist eine CLI um Domänen, Entitäten, Eigenschaften und Beziehungen zur Contract Architektur hinzuzufügen.</Description>
     <Authors>Jonas Hammerschmidt</Authors>

--- a/Contractor.CLI/Xml/ContractorXml.cs
+++ b/Contractor.CLI/Xml/ContractorXml.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Xml;
-using System.Xml.Serialization;
+﻿using System.Xml.Serialization;
 
 namespace Contractor.CLI
 {
@@ -172,6 +170,9 @@ namespace Contractor.CLI
 
         [XmlAttribute(AttributeName = "hidden")]
         public bool IsHidden { get; set; }
+        
+        [XmlAttribute(AttributeName = "minLength")]
+        public string MinLength { get; set; }
     }
 
     [XmlRoot(ElementName = "Index")]

--- a/Contractor.CLI/Xml/ContractorXmlConverter.cs
+++ b/Contractor.CLI/Xml/ContractorXmlConverter.cs
@@ -79,6 +79,7 @@ namespace Contractor.CLI
                             IsOptional = property.IsOptional,
                             IsDisplayProperty = property.IsDisplayProperty,
                             IsHidden = property.IsHidden,
+                            MinLength = string.IsNullOrWhiteSpace(property.MinLength) ? 1 : int.Parse(property.MinLength),
                         }).ToList(),
                         Relations1To1 = entity.Relations1To1.Select(relation1To1 => new Relation1To1()
                         {

--- a/Contractor.CLI/Xml/ContractorXmlOrderSetter.cs
+++ b/Contractor.CLI/Xml/ContractorXmlOrderSetter.cs
@@ -30,7 +30,7 @@ namespace Contractor.CLI
                 foreach (XmlNode propertyNode in propertyNodes)
                 {
                     var propertyName = propertyNode.Attributes?["name"]?.Value;
-                    var property = entity.Properties.FirstOrDefault(p => p.Name == propertyName);
+                    var property = entity.Properties.FirstOrDefault(p => string.Equals(p.Name, propertyName, StringComparison.OrdinalIgnoreCase));
                     if (property != null)
                     {
                         property.Order = propertyNode.GetNodeIndex();
@@ -48,7 +48,9 @@ namespace Contractor.CLI
                 {
                     string entityNameFrom = relationNode.Attributes?["entityNameFrom"]?.Value;
                     string propertyNameFrom = relationNode.Attributes?["propertyNameFrom"]?.Value;
-                    var relation = entity.Relations1To1.FirstOrDefault(r => r.TargetEntity.Name == entityNameFrom && r.PropertyNameInSource == propertyNameFrom);
+                    var relation = entity.Relations1To1.FirstOrDefault(r =>
+                        string.Equals(r.TargetEntity.Name, entityNameFrom, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(r.PropertyNameInSource, propertyNameFrom, StringComparison.OrdinalIgnoreCase));
                     if (relation != null)
                     {
                         relation.Order = relationNode.GetNodeIndex();
@@ -66,7 +68,9 @@ namespace Contractor.CLI
                 {
                     string entityNameFrom = relationNode.Attributes?["entityNameFrom"]?.Value;
                     string propertyNameFrom = relationNode.Attributes?["propertyNameFrom"]?.Value;
-                    var relation = entity.Relations1ToN.FirstOrDefault(r => r.TargetEntity.Name == entityNameFrom && r.PropertyNameInSource == propertyNameFrom);
+                    var relation = entity.Relations1ToN.FirstOrDefault(r =>
+                        string.Equals(r.TargetEntity.Name, entityNameFrom, StringComparison.OrdinalIgnoreCase)
+                        && string.Equals(r.PropertyNameInSource, propertyNameFrom, StringComparison.OrdinalIgnoreCase));
                     if (relation != null)
                     {
                         relation.Order = relationNode.GetNodeIndex();

--- a/Contractor.CLI/Xml/ContractorXmlValidators.cs
+++ b/Contractor.CLI/Xml/ContractorXmlValidators.cs
@@ -130,6 +130,42 @@ public class ContractorXmlValidator
             {
                 throw new FormatException($"Entity '{entity.Name}': Duplicate property name '{firstDuplicate}'.");
             }
+
+            foreach (var property in entity.Properties)
+            {
+                var isValidType = Regex.IsMatch(property.Type, @"^(Boolean|ByteArray|DateTime|Double|Guid|Integer|String:\d+)$");
+                if (!isValidType)
+                {
+                    throw new FormatException($"Entity '{entity.Name}': Property '{property.Name}': Invalid type '{property.Type}'");
+                }
+
+                var isTypeStringMatchResult = Regex.Match(property.Type, "^String:([0-9]+)$");
+                
+                if (isTypeStringMatchResult.Success)
+                {
+                    string maxLengthString = isTypeStringMatchResult.Groups[1].Value;
+                    int maxLengthInt = int.Parse(maxLengthString);
+
+                    if (maxLengthInt <= 0)
+                    {
+                        throw new FormatException($"Entity '{entity.Name}': Property '{property.Name}' of type 'String': maxLength cannot be smaller than 1.");
+                    }
+
+                    if (int.TryParse(property.MinLength, out int minLength))
+                    {
+                        if (minLength < 0)
+                        {
+                            throw new FormatException($"Entity '{entity.Name}': Property '{property.Name}' of type 'String': minLength cannot be smaller than 0.");
+                        }
+                        
+                        if (maxLengthInt < minLength)
+                        {
+                            throw new FormatException($"Entity '{entity.Name}': Property '{property.Name}' of type 'String': maxLength cannot be smaller than minLength.");
+                        }
+                    }
+                }
+            }
+            
         }
     }
 

--- a/Contractor.Core/Generation/GenerationHelpers/SharedServices/DTOs/ApiDtoPropertyAddition.cs
+++ b/Contractor.Core/Generation/GenerationHelpers/SharedServices/DTOs/ApiDtoPropertyAddition.cs
@@ -34,9 +34,15 @@ namespace Contractor.Core.Tools
                 stringEditor.InsertNewLine();
             }
 
-            if (!property.IsOptional)
+            bool areEmptyStringsAllowed = property.Type == PropertyType.String && property.MinLength == 0;
+            if (!property.IsOptional && !areEmptyStringsAllowed)
             {
                 stringEditor.InsertLine("        [Required]");
+            }
+
+            if (!property.IsOptional && areEmptyStringsAllowed)
+            {
+                stringEditor.InsertLine("        [Required(AllowEmptyStrings = true)]");
             }
 
             if (property.Type == PropertyType.String && property.TypeExtra != null && property.IsOptional)
@@ -46,7 +52,7 @@ namespace Contractor.Core.Tools
 
             if (property.Type == PropertyType.String && property.TypeExtra != null && !property.IsOptional)
             {
-                stringEditor.InsertLine($"        [StringLength({property.TypeExtra}, MinimumLength = 1)]");
+                stringEditor.InsertLine($"        [StringLength({property.TypeExtra}, MinimumLength = {property.MinLength})]");
             }
 
             stringEditor.InsertLine(BackendDtoPropertyLine.GetPropertyLine(property));

--- a/Contractor.Core/Generation/GenerationHelpers/SharedServices/DTOs/FrontendDtoRelationAddition.cs
+++ b/Contractor.Core/Generation/GenerationHelpers/SharedServices/DTOs/FrontendDtoRelationAddition.cs
@@ -37,7 +37,8 @@ namespace Contractor.Core.Tools
             }
             stringEditor.NextThatContains("}");
 
-            stringEditor.InsertLine($"    {relationSide.NameLower}: {relationSide.Type};");
+            string optionalText = (relationSide.IsOptional) ? "?" : "";
+            stringEditor.InsertLine($"    {relationSide.NameLower}{optionalText}: {relationSide.Type};");
 
             return stringEditor.GetText();
         }

--- a/Contractor.Core/Generation/GenerationPreprocessor.cs
+++ b/Contractor.Core/Generation/GenerationPreprocessor.cs
@@ -17,6 +17,7 @@ namespace Contractor.Core
                 {
                     foreach (var relation1To1 in entity.Relations1To1)
                     {
+                        // Adding ScopeRelations from unscoped source entities to scoped target entities
                         if ((relation1To1.TargetEntity.HasScope && !relation1To1.SourceEntity.HasScope) || relation1To1.SourceEntity.HasOtherScope(relation1To1.TargetEntity))
                         {
                             Relation1ToN scopeRelation1ToN = new Relation1ToN()
@@ -39,6 +40,7 @@ namespace Contractor.Core
 
                     foreach (var relation1ToN in entity.Relations1ToN)
                     {
+                        // Adding ScopeRelations from unscoped source entities to scoped target entities
                         if ((relation1ToN.TargetEntity.HasScope && !relation1ToN.SourceEntity.HasScope) || relation1ToN.SourceEntity.HasOtherScope(relation1ToN.TargetEntity))
                         {
                             Relation1ToN scopeRelation1ToN = new Relation1ToN()

--- a/Contractor.Core/Generation/Generators/Backend/Generated.DTOs/DTOs/EntityDtoForPurpose/EntityDtoForPurposeGeneration.cs
+++ b/Contractor.Core/Generation/Generators/Backend/Generated.DTOs/DTOs/EntityDtoForPurpose/EntityDtoForPurposeGeneration.cs
@@ -112,10 +112,16 @@ namespace Contractor.Core.Generation.Backend.Generated.DTOs
                 {
                     RelationSide relationSideFrom = RelationSide.FromObjectRelationEndFrom(lastPathItem.Relation, "", dtoPostfix);
 
-                    this.relationAddition.AddRelationToDTOForBackendGenerated(relationSideFrom, GeneratedDTOsProjectGeneration.DomainFolder, $"{dtoName}.cs",
+                    this.relationAddition.AddRelationToDTOForBackendGenerated(
+                        relationSideFrom,
+                        GeneratedDTOsProjectGeneration.DomainFolder,
+                        $"{dtoName}.cs",
                         $"{relationSideFrom.Entity.Module.Options.Paths.GeneratedProjectName}.Modules.{relationSideFrom.OtherEntity.Module.Name}.{relationSideFrom.OtherEntity.NamePlural}");
 
-                    this.entityDtoForPurposeFromOneToOneMethodsAddition.AddRelationSideToBackendGeneratedFile(relationSideFrom, GeneratedDTOsProjectGeneration.DomainFolder,
+                    this.entityDtoForPurposeFromOneToOneMethodsAddition.AddRelationSideToBackendGeneratedFile(
+                        relationSideFrom,
+                        relationSideFrom.OtherEntity.Name + dtoPostfix,
+                        GeneratedDTOsProjectGeneration.DomainFolder,
                         $"{dtoName}.cs");
                 }
                 else

--- a/Contractor.Core/Generation/Generators/Backend/Persistence/Generation/EntitiesCrudRepository/EntitiesCrudRepositoryGeneration.cs
+++ b/Contractor.Core/Generation/Generators/Backend/Persistence/Generation/EntitiesCrudRepository/EntitiesCrudRepositoryGeneration.cs
@@ -16,20 +16,20 @@ namespace Contractor.Core.Generation.Backend.Persistence
 
         private readonly EntityCoreAddition entityCoreAddition;
         private readonly EntitiesCrudRepositoryToRelationAddition entitiesCrudRepositoryToRelationAddition;
-        private readonly EntitiesCrudRepositoryToIncludeAddition dtoToRepositoryIncludeAddition;
+        private readonly EntitiesCrudRepositoryToIncludeAddition entitiesCrudRepositoryToIncludeAddition;
         private readonly EntitiesCrudRepositoryToOneToOneIncludeAddition entitiesCrudRepositoryToOneToOneIncludeAddition;
         private readonly EntitiesCrudRepositoryPurposeDtoInserter entitiesCrudRepositoryPurposeDtoInserter;
 
         public EntitiesCrudRepositoryGeneration(
             EntityCoreAddition entityCoreAddition,
             EntitiesCrudRepositoryToRelationAddition entitiesCrudRepositoryToRelationAddition,
-            EntitiesCrudRepositoryToIncludeAddition dtoToRepositoryIncludeAddition,
+            EntitiesCrudRepositoryToIncludeAddition entitiesCrudRepositoryToIncludeAddition,
             EntitiesCrudRepositoryToOneToOneIncludeAddition entitiesCrudRepositoryToOneToOneIncludeAddition,
             EntitiesCrudRepositoryPurposeDtoInserter entitiesCrudRepositoryPurposeDtoInserter)
         {
             this.entityCoreAddition = entityCoreAddition;
             this.entitiesCrudRepositoryToRelationAddition = entitiesCrudRepositoryToRelationAddition;
-            this.dtoToRepositoryIncludeAddition = dtoToRepositoryIncludeAddition;
+            this.entitiesCrudRepositoryToIncludeAddition = entitiesCrudRepositoryToIncludeAddition;
             this.entitiesCrudRepositoryToOneToOneIncludeAddition = entitiesCrudRepositoryToOneToOneIncludeAddition;
             this.entitiesCrudRepositoryPurposeDtoInserter = entitiesCrudRepositoryPurposeDtoInserter;
         }
@@ -55,7 +55,7 @@ namespace Contractor.Core.Generation.Backend.Persistence
         {
             RelationSide relationSideTo = RelationSide.FromObjectRelationEndTo(relation, "", "");
 
-            this.dtoToRepositoryIncludeAddition.AddRelationSideToBackendFile(relationSideTo, PersistenceProjectGeneration.DomainFolder, FileName);
+            this.entitiesCrudRepositoryToIncludeAddition.AddRelationSideToBackendFile(relationSideTo, PersistenceProjectGeneration.DomainFolder, FileName);
             this.entitiesCrudRepositoryToRelationAddition.AddRelationSideToBackendFile(relationSideTo, PersistenceProjectGeneration.DomainFolder, FileName);
         }
 

--- a/Contractor.Core/Generation/Options/MetaModell/Property.cs
+++ b/Contractor.Core/Generation/Options/MetaModell/Property.cs
@@ -36,6 +36,8 @@ namespace Contractor.Core.MetaModell
 
         public bool IsHidden { get; set; }
 
+        public int MinLength { get; set; }
+
         public int Order { get; set; }
 
         public Entity Entity { get; set; }

--- a/Contractor.Core/Generation/Options/MetaModell/Relation.cs
+++ b/Contractor.Core/Generation/Options/MetaModell/Relation.cs
@@ -58,7 +58,7 @@ namespace Contractor.Core.MetaModell
 
         public Entity SourceEntity { get; set; }
 
-        public void AddLinks(Entity entity)
+        public virtual void AddLinks(Entity entity)
         {
             SourceEntity = entity;
             TargetEntity = entity.Module.Options.FindEntity(targetEntityName);

--- a/Contractor.Core/Generation/Options/MetaModell/Relation1To1.cs
+++ b/Contractor.Core/Generation/Options/MetaModell/Relation1To1.cs
@@ -9,5 +9,13 @@
         public Relation1To1(Relation relation) : base(relation)
         {
         }
+
+        public override void AddLinks(Entity entity)
+        {
+            base.AddLinks(entity);
+
+            this.PropertyNameInSource ??= TargetEntity.Name;
+            this.PropertyNameInTarget ??= SourceEntity.Name;
+        }
     }
 }

--- a/Contractor.Core/Generation/Options/MetaModell/Relation1ToN.cs
+++ b/Contractor.Core/Generation/Options/MetaModell/Relation1ToN.cs
@@ -1,4 +1,6 @@
-﻿namespace Contractor.Core.MetaModell
+﻿using System.Transactions;
+
+namespace Contractor.Core.MetaModell
 {
     public class Relation1ToN : Relation
     {
@@ -21,6 +23,14 @@
             this.OnDelete = "NoAction";
             this.Order = -1;
             this.IsCreatedByPreProcessor = true;
+        }
+
+        public override void AddLinks(Entity entity)
+        {
+            base.AddLinks(entity);
+
+            this.PropertyNameInSource ??= TargetEntity.Name;
+            this.PropertyNameInTarget ??= SourceEntity.NamePlural;
         }
     }
 }

--- a/Contractor.Core/Generation/Options/MetaModell/RelationSide.cs
+++ b/Contractor.Core/Generation/Options/MetaModell/RelationSide.cs
@@ -75,7 +75,7 @@ namespace Contractor.Core.MetaModell
             {
                 Entity = relation.TargetEntity,
                 IsDisplayProperty = false,
-                IsOptional = relation.IsOptional,
+                IsOptional = true,
                 OnDelete = relation.OnDelete,
                 Name = name,
                 Order = int.MaxValue,

--- a/Contractor.XML/XSD/contractor-modules.xsd
+++ b/Contractor.XML/XSD/contractor-modules.xsd
@@ -34,7 +34,7 @@
                           </xs:annotation>
                           <xs:simpleType>
                             <xs:restriction base="xs:string">
-                              <xs:pattern value="Boolean|ByteArray|DateTime|Double|Guid|Integer|(String(:[0-9]+)?)" />
+                              <xs:pattern value="Boolean|ByteArray|DateTime|Double|Guid|Integer|(String:[0-9]+)" />
                             </xs:restriction>
                           </xs:simpleType>
                         </xs:attribute>
@@ -51,6 +51,11 @@
                         <xs:attribute name="hidden" type="xs:boolean" use="optional">
                           <xs:annotation>
                             <xs:documentation xml:lang="de">Optional. Definition, ob diese Property aus den generierten DTOs entfernt werden soll. Default: False.</xs:documentation>
+                          </xs:annotation>
+                        </xs:attribute>
+                        <xs:attribute name="minLength" type="xs:integer" use="optional">
+                          <xs:annotation>
+                            <xs:documentation xml:lang="de">Optional. Angabe für die Mindestlänge dieser Property. Wird nur bei Property-Type "String" angewandt. Default: 1</xs:documentation>
                           </xs:annotation>
                         </xs:attribute>
                       </xs:complexType>


### PR DESCRIPTION
Feature: Added MinLength to String Property

Fix: Repo.Update enthält falschen Lookup bei fremden Scope #104 
Fix: Purpose-DTO-Path via 1:1-From-Side breaks #102 
Fix: Fehlende Optional-Markierung im Frontend-Expanded-DTO auf der From-Seite #101 
Fix: Fehler wenn Property name klein geschrieben wird #98 